### PR TITLE
Simplifying the Rust implementation into a single function.

### DIFF
--- a/arithmetic_progression.rs
+++ b/arithmetic_progression.rs
@@ -1,10 +1,10 @@
-// https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=728dc7ff9604838c8fd48094e6128674
+// https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=089f256c88db476e31d4f4a1ffcffb0b
 
 use itertools::Itertools;
 use std::fmt::Display;
 
-fn is_arithmetic_progression<T: Copy + PartialOrd + std::ops::Sub<Output = T> + PartialEq>(
-    nums: &[T],
+fn is_arithmetic_progression<T: Copy + PartialOrd + std::ops::Sub<Output = T>
+    + PartialEq>(nums: &[T],
 ) -> bool {
     nums.iter()
         .sorted_by(|a, b| a.partial_cmp(b).unwrap())


### PR DESCRIPTION
Code changes the following:
- Copy of iterator items moved further back
- `all_equal` function replaced by `itertools::all_equal`

Playground link has been updated; Minor formatting changes