### PR TITLE
Improve Rust version using impl Trait, trait bounds, IntoIterator

### DIFF
--- a/arithmetic_progression.rs
+++ b/arithmetic_progression.rs
@@ -1,7 +1,7 @@
-// https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=6dffd87fed6953f9e415195359683f3b
+// https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=b566dfe86b1744e6c14ad63efc7aa303
 
 use itertools::Itertools;
-use std::{fmt::Display, ops::Sub};
+use std::{fmt::Debug, ops::Sub};
 
 fn is_arithmetic_progression(
     nums: impl IntoIterator<Item: Copy + PartialOrd + Sub<Output: PartialEq>>,
@@ -15,23 +15,16 @@ fn is_arithmetic_progression(
         .all_equal()
 }
 
-fn print_result(example: usize, nums: &[impl Display], result: bool) {
-    print!("Example {}:\nInput: [", example);
-    for (i, num) in nums.iter().enumerate() {
-        if i > 0 {
-            print!(", ");
-        }
-        print!("{}", num);
-    }
-    println!("]\nOutput: {}\n", result);
+fn print_result(example: usize, nums: impl Debug, result: bool) {
+    print!("Example {example}:\nInput: {nums:?}\nOutput: {result}\n");
 }
 
 fn main() {
-    let nums1 = vec![1, 3, 5, 7, 9];
-    let nums2 = vec![9, 1, 7, 5, 3];
-    let nums3 = vec![1, 2, 4, 8, 16];
-    let nums4 = vec![5, -1, 3, 1, -3];
-    let nums5 = vec![1.5, 3.0, 0.0, 4.5, 6.0];
+    let nums1 = [1, 3, 5, 7, 9];
+    let nums2 = [9, 1, 7, 5, 3];
+    let nums3 = [1, 2, 4, 8, 16];
+    let nums4 = [5, -1, 3, 1, -3];
+    let nums5 = [1.5, 3.0, 0.0, 4.5, 6.0];
 
     print_result(1, &nums1, is_arithmetic_progression(&nums1));
     print_result(2, &nums2, is_arithmetic_progression(&nums2));


### PR DESCRIPTION
Improve Rust version using:
- impl Trait
- trait bounds
- `IntoIterator`

Simplify implementation:
- simplify `print_result()`
- remove `vec!`

Also added comment for using the currently experimental Nightly-only `map_windows`, which turns
```
        .tuple_windows()
        .map(|(a, b)| b - a)
```
into just
```
        .map_windows(|&[a, b]| b - a)
```