### PR TITLE
Use `total_cmp` for floats

### DIFF
--- a/arithmetic_progression.rs
+++ b/arithmetic_progression.rs
@@ -1,16 +1,55 @@
 // https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=9729edf14743236bf3e936225c8d7880
+#![feature(iter_map_windows)]
 
 use itertools::Itertools;
-use std::{fmt::Debug, ops::Sub};
+use core::{fmt::Debug, ops::Sub, cmp::Ordering};
 
 fn is_arithmetic_progression(
-    nums: impl IntoIterator<Item: Copy + PartialOrd + Sub<Output: PartialEq>>,
+    nums: impl IntoIterator<Item: Copy + TotalOrd + Sub<Output: PartialEq>>,
 ) -> bool {
     nums.into_iter()
-        .sorted_by(|a, b| a.partial_cmp(b).unwrap())
+        .sorted_by(TotalOrd::total_cmp)
         .map_windows(|&[a, b]| b - a)
         .all_equal()
 }
+
+trait TotalOrd {
+    fn total_cmp(&self, rhs: &Self) -> Ordering;
+}
+
+impl<T: TotalOrd> TotalOrd for &T {
+    fn total_cmp(&self, rhs: &Self) -> Ordering {
+        (**self).total_cmp(*rhs)
+    }
+}
+
+macro_rules! impl_float {
+    ($($ty:ty)+) => {
+        $(
+            impl TotalOrd for $ty {
+                fn total_cmp(&self, rhs: &Self) -> Ordering {
+                    <$ty>::total_cmp(self, rhs)
+                }
+            }
+        )+
+    }
+}
+
+impl_float!(f32 f64);
+
+macro_rules! impl_int {
+    ($($ty:ty)+) => {
+        $(
+            impl TotalOrd for $ty {
+                fn total_cmp(&self, rhs: &Self) -> Ordering {
+                    <$ty>::cmp(self, rhs)
+                }
+            }
+        )+
+    }
+}
+
+impl_int!(i8 i16 i32 i64 i128 isize u8 u16 u32 u64 u128 usize);
 
 fn print_result(example: usize, nums: impl Debug, result: bool) {
     print!("Example {example}:\nInput: {nums:?}\nOutput: {result}\n");


### PR DESCRIPTION
Hi there. I was experimenting on a solution that would be more robust for floats (in case of NaN values). There is a method defined for floats in `std`, called `total_cmp`, that allows for total ordering of NaN values, but I had to implement a custom `trait` to use the `is_arithmetic_progression` for all applicable types.

Unfortunately, the blanket `impl<T: Ord> TotalOrd for T` is not possible to be used together with a separate `impl` for floats, due to the "possible future implementation of `Ord` on `{float}`" (which will never happen, but oh well). I guess this could probably be solved with the trait specialization nightly feature... 

To reduce repetitions, I've made the `macro_rules!` declarative macros which generate the `impl` blocks for all integers and floats. The `impl_int` macro could also be used for any other `impl Ord` type, but only manually...

I'm not sure the solution is that good to be merged, so just a draft PR.